### PR TITLE
ISSUE-182 refactor: remove periodic cleanup of expired cache entries and adjust…

### DIFF
--- a/src/lib/cache.ts
+++ b/src/lib/cache.ts
@@ -70,15 +70,15 @@ export async function getCachedAnalysis(
 
     const sql = getDatabase();
 
-    // Clean up expired entries periodically (10% chance)
-    if (Math.random() < 0.1) {
-      await cleanupExpiredEntries();
-    }
+    // // Clean up expired entries periodically (10% chance)
+    // if (Math.random() < 0.1) {
+    //   await cleanupExpiredEntries();
+    // }
 
     const result = await sql`
-      SELECT data, created_at, expires_at 
+      SELECT data, created_at 
       FROM cache 
-      WHERE cache_key = ${cacheKey} AND expires_at > NOW()
+      WHERE cache_key = ${cacheKey}
       LIMIT 1
     `;
 
@@ -157,7 +157,6 @@ export async function getRecentAnalyses(): Promise<
     const result = await sql`
       SELECT cache_key, data, created_at
       FROM cache
-      WHERE expires_at > NOW()
       ORDER BY created_at DESC
       LIMIT 3
     `;


### PR DESCRIPTION
… SQL queries
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Removed periodic cleanup of expired cache entries and adjusted SQL queries to ignore expiration, aligning cache behavior with updated business requirements that make expiration irrelevant for now. This simplifies cache management and ensures all cached analyses remain accessible regardless of their age.

**What Changed**
- Commented out the random periodic cleanup of expired cache entries in the cache retrieval logic
- Updated SQL queries to remove references to the `expires_at` field, so cache entries are no longer filtered by expiration
- Ensured recent analyses retrieval no longer excludes expired entries

**Why This Matters**
- Aligns cache behavior with the latest business direction (per Linear ISSUE-182) by making expiration non-blocking for analysis retrieval
- Reduces unnecessary database operations, potentially improving performance and lowering operational complexity
- Ensures users and developers have consistent access to all cached analyses, regardless of their creation or expiration date

**Implementation Details**
- The cleanup logic is preserved in comments for potential future reactivation, minimizing code churn if requirements change again
- No breaking changes to the cache API or data structure; only the filtering and cleanup logic are affected
- No migration steps required, as existing cache entries remain valid and accessible

<!-- End of auto-generated description by cubic. -->

