### PR TITLE
ISSUE-182 refactor: remove periodic cleanup of expired cache entries and adjust…

### DIFF
--- a/src/lib/cache.ts
+++ b/src/lib/cache.ts
@@ -70,15 +70,15 @@ export async function getCachedAnalysis(
 
     const sql = getDatabase();
 
-    // Clean up expired entries periodically (10% chance)
-    if (Math.random() < 0.1) {
-      await cleanupExpiredEntries();
-    }
+    // // Clean up expired entries periodically (10% chance)
+    // if (Math.random() < 0.1) {
+    //   await cleanupExpiredEntries();
+    // }
 
     const result = await sql`
-      SELECT data, created_at, expires_at 
+      SELECT data, created_at 
       FROM cache 
-      WHERE cache_key = ${cacheKey} AND expires_at > NOW()
+      WHERE cache_key = ${cacheKey}
       LIMIT 1
     `;
 
@@ -157,7 +157,6 @@ export async function getRecentAnalyses(): Promise<
     const result = await sql`
       SELECT cache_key, data, created_at
       FROM cache
-      WHERE expires_at > NOW()
       ORDER BY created_at DESC
       LIMIT 3
     `;


### PR DESCRIPTION
https://app.asana.com/1/1210778931885983/project/1210778808809069/task/1210778808809084?focus=true
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Removed periodic cleanup of expired cache entries and updated cache queries to ignore expiration.

- **Refactors**
 - Commented out random cleanup logic.
 - Removed all uses of the expires_at field in cache queries.

<!-- End of auto-generated description by cubic. -->

---
**Associated Linear Issue Context**
This pull request is associated with the following Linear issue: https://linear.app/withperpetual/issue/ISSUE-182/make-the-expira-not-relevant-for-now. false

**Title:** Make the expira not relevant for now
**Status:** In Progress
**Priority:** No priority
**Assignee:** santiago

**Team:** perpetual


**Description:**
make the expiration not relevant

and removed the aichat component

You may use this information to help in your task.

**Associated Asana Task Context**
This pull request is associated with the following Asana task: https://app.asana.com/1/1210778931885983/project/1210778808809069/task/1210778808809084. 

**Title:** as
**Status:** In Progress
**Assignee:** Santiago
**Due Date:** 7/14/2025

**Created By:** Santiago

**Description:**
this is awesome ahahahahhaa
🙂


im santiago hahaha



hey

**Projects:** as

**Recent Comments:**
- Santiago (7/11/2025): Santiago assigned to you
- Santiago (7/11/2025): Santiago added to as
- Santiago (7/11/2025): Santiago changed the due date to Tomorrow
- Santiago (7/14/2025): Santiago moved this task from "To do" to "Done" in as
- Santiago (7/14/2025): Santiago changed the name to "as"

**Custom Fields:**
- Priority: Low
- Status: On track

You may use this information to help in your task.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Disabled automatic cleanup of expired cache entries.
  * Modified cache retrieval to include expired entries in results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->