### PR TITLE
ISSUE-182 refactor: remove periodic cleanup of expired cache entries and adjust…

### DIFF
--- a/src/lib/cache.ts
+++ b/src/lib/cache.ts
@@ -70,15 +70,15 @@ export async function getCachedAnalysis(
 
     const sql = getDatabase();
 
-    // Clean up expired entries periodically (10% chance)
-    if (Math.random() < 0.1) {
-      await cleanupExpiredEntries();
-    }
+    // // Clean up expired entries periodically (10% chance)
+    // if (Math.random() < 0.1) {
+    //   await cleanupExpiredEntries();
+    // }
 
     const result = await sql`
-      SELECT data, created_at, expires_at 
+      SELECT data, created_at 
       FROM cache 
-      WHERE cache_key = ${cacheKey} AND expires_at > NOW()
+      WHERE cache_key = ${cacheKey}
       LIMIT 1
     `;
 
@@ -157,7 +157,6 @@ export async function getRecentAnalyses(): Promise<
     const result = await sql`
       SELECT cache_key, data, created_at
       FROM cache
-      WHERE expires_at > NOW()
       ORDER BY created_at DESC
       LIMIT 3
     `;


### PR DESCRIPTION
… SQL queries
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Removed the periodic cleanup of expired cache entries and updated SQL queries to no longer filter by expiration.

<!-- End of auto-generated description by cubic. -->


<table>
  <thead>
    <tr>
      <th width="150">Status</th>
      <th width="250">Criteria</th>
      <th>Notes</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td width="150"><strong>✅</strong></td>
      <td width="250">Make the expiration not relevant</td>
      <td>The code changes in src/lib/cache.ts show that the expiration checks (expires_at) have been removed from SQL queries and the periodic cleanup of expired cache entries has been commented out, making expiration not relevant.</td>
    </tr>
    <tr>
      <td width="150"><strong>❌</strong></td>
      <td width="250">Remove the aichat component</td>
      <td>No evidence found in the provided code changes that the aichat component was removed. The diff only shows changes in src/lib/cache.ts related to expiration logic, with no mention or removal of any aichat component.</td>
    </tr>
  </tbody>
</table>
