### PR TITLE
ISSUE-182 refactor: remove periodic cleanup of expired cache entries and adjust…

### DIFF
--- a/src/lib/cache.ts
+++ b/src/lib/cache.ts
@@ -70,15 +70,15 @@ export async function getCachedAnalysis(
 
     const sql = getDatabase();
 
-    // Clean up expired entries periodically (10% chance)
-    if (Math.random() < 0.1) {
-      await cleanupExpiredEntries();
-    }
+    // // Clean up expired entries periodically (10% chance)
+    // if (Math.random() < 0.1) {
+    //   await cleanupExpiredEntries();
+    // }
 
     const result = await sql`
-      SELECT data, created_at, expires_at 
+      SELECT data, created_at 
       FROM cache 
-      WHERE cache_key = ${cacheKey} AND expires_at > NOW()
+      WHERE cache_key = ${cacheKey}
       LIMIT 1
     `;
 
@@ -157,7 +157,6 @@ export async function getRecentAnalyses(): Promise<
     const result = await sql`
       SELECT cache_key, data, created_at
       FROM cache
-      WHERE expires_at > NOW()
       ORDER BY created_at DESC
       LIMIT 3
     `;


### PR DESCRIPTION
… SQL queries
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Removed the periodic cleanup of expired cache entries and updated SQL queries to no longer filter by expiration.

- **Refactors**
  - Commented out random cleanup logic.
  - Removed expires_at checks from cache queries.

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where expired cache entries were being excluded from retrieval; now all cached entries, including expired ones, are accessible.
  * Disabled automatic periodic cleanup of expired cache entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->